### PR TITLE
fix description not accepting strings with spaces

### DIFF
--- a/lib/Win32/ServiceManager.pm
+++ b/lib/Win32/ServiceManager.pm
@@ -70,7 +70,7 @@ sub _depends {
 
 sub _sc_failure { qw(sc failure), $_[1], 'reset= 60', 'actions= restart/60000' }
 
-sub _sc_description { qw(sc description), $_[1], $_[2] }
+sub _sc_description { qw(sc description), $_[1], qq("$_[2]") }
 
 sub create_service {
    my ($self, %args) = @_;


### PR DESCRIPTION
If you don't wrap the description in spaces, everything after the
first space is discarded.
