### PR TITLE
Remove the 'args' argument in service installation

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,13 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+0.002006  2019-11-18 16:11:46 IT/Piacenza
+ - removed 'args' argument from _sc_install due to wrong positioning inside the sc create command that is being triggered. From now on, we just
+let the user configure the full binpath string in the "command" argument
+
+0.002005  2018-07-31 19:08:22-05:00 America/Chicago
+ - add optional start type config
+
 0.002004  2018-02-13 16:25:46-06:00 America/Chicago
  - add optional user and password configs
 

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author           = Arthur Axel "fREW" Schmidt <frioux+cpan@gmail.com>
 author           = Wes Malone <wesm@cpan.org>
 license          = Perl_5
 copyright_holder = Arthur Axel "fREW" Schmidt
-version          = 0.002004
+version          = 0.002006
 
 [NextRelease]
 [@Git]

--- a/lib/Win32/ServiceManager.pm
+++ b/lib/Win32/ServiceManager.pm
@@ -55,7 +55,7 @@ sub _nssm_install {
 }
 
 sub _sc_install {
-   qw(sc create), $_[1], qq(binpath= "$_[2]") . ($_[3] ?  " $_[3]" : ''),
+   qw(sc create), $_[1], qq(binpath= "$_[2]"),
 }
 
 sub _sc_configure {
@@ -115,6 +115,7 @@ sub create_service {
 
    my $name    = $args{name}    or die 'name is required!';
    my $display = $args{display} or die 'display is required!';
+   die "'args' argument not available" if $args{args};
    die "can't provide a password without a 'user'" if $args{password} && !$args{user};
 
    my $description = $args{description};

--- a/lib/Win32/ServiceManager.pm
+++ b/lib/Win32/ServiceManager.pm
@@ -318,6 +318,7 @@ __END__
     command =>
        $dir->file(qw( App script server.pl ))->stringify .
           ' -p 3001',
+    check_command => 0,
  );
  $sc->start_service('LynxWebServer01', { non_blocking => 0 });
  $sc->stop_service('LynxWebServer01');
@@ -334,6 +335,7 @@ __END__
     use_perl    => 1,
     use_nssm    => 1,
     command     => 'C:\code\GR\script\server.pl -p 3001',
+    check_command => 0,
     depends     => [qw(MSSQL Apache2.4)],
     start       => 'delayed-auto',
     user        => 'DOMAIN\username',
@@ -370,16 +372,11 @@ will have to set C<use_perl> to false.
 
 (defaults to the value of L<check_command_default>) This will check that the
 command you passed exists on the filesystem and if it does not exists it will
-die
+die. Please note that if you want to pass some parameter to your command, then you need to set check_command => 0
 
 =item * C<command>
 
 (required) The command that is effectively your service
-
-=item * C<args>
-
-(optional) Arguments that get passed to the command above.
-XXX: do these even make sense?
 
 =item * C<depends>
 
@@ -634,6 +631,7 @@ example we have a subclass that looks something like the following:
        command =>
           $dir->file(qw( App script server.pl ))->stringify .
              " -p 300$i",
+        check_command => 0,
     );
 
  }

--- a/lib/Win32/ServiceManager.pm
+++ b/lib/Win32/ServiceManager.pm
@@ -142,10 +142,9 @@ sub create_service {
       if ($use_perl) {
          $command = $^X;
          die 'command is required!' unless $args{command};
-         $args = $args{command} . ($args{args} ? " $args{args}" : '')
+         $args = $args{command}
       } else {
          $command = $args{command} or die 'command is required!';
-         $args = $args{args};
       }
 
       if ($nssm) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -61,4 +61,13 @@ cmp_deeply(
    'sc configure auth ok',
 );
 
+cmp_deeply(
+   [$sm->_sc_configure('foo', {display => 'Foo', start => 'delayed-auto'})],
+   [qw(sc config foo),
+      'DisplayName= "Foo"',
+      'type= own start= delayed-auto',
+   ],
+   'sc configure start ok',
+);
+
 done_testing;


### PR DESCRIPTION
Drop the 'args' option since it doesn't work. Review the
syntax for sc command, Let the user configure the full binpath string in the "command" argument.